### PR TITLE
Fixed Compilation on Linux

### DIFF
--- a/src/wallet.h
+++ b/src/wallet.h
@@ -19,7 +19,7 @@
 #include "walletdb.h"
 
 // Settings
-extern int64_t nTransactionFee;
+extern int64 nTransactionFee;
 extern int64_t nReserveBalance;
 extern int64_t nMinimumInputValue;
 extern bool fWalletUnlockStakingOnly;


### PR DESCRIPTION
No known conversion from 'int64_t {aka long int}' to 'int64& {aka long long int&}'. However, int64 should work just fine.
